### PR TITLE
Fix endless token fetch if dualis is down

### DIFF
--- a/dualis_connector/dualis_service.py
+++ b/dualis_connector/dualis_service.py
@@ -39,15 +39,28 @@ class DualisService:
 
         token = None
         cnsc = None
-        while token is None:
+        retries = 0
+        while token is None and retries < 5:
+            retries += 1
             if not dualis_username or not dualis_password:
-                sys.exit('Credentials not specified correctly, aborting, ...')
+                msg = 'Credentials not specified correctly, aborting, ...'
+                logging.debug(msg)
+                sys.exit(msg)
             try:
                 token, cnsc = login_helper.obtain_login_token(dualis_username, dualis_password)
             except RequestRejectedError as error:
-                print('Login Failed! (%s) Please try again.' % (error))
+                msg = 'Login Failed! (%s) Please try again.' % (error)
+                logging.debug(msg)
+                print(msg)
             except (ValueError, RuntimeError) as error:
-                print('Error while communicating with the Dualis System! (%s) Please try again.' % (error))
+                msg = 'Error while communicating with the Dualis System! (%s) Please try again.' % (error)
+                logging.debug(msg)
+                print(msg)
+        if token is None and retries >= 5:
+            msg = "Error: maximum retries reached, aborting..."
+            print(msg)
+            logging.debug(msg)
+            raise Exception(msg)
 
         self.config_helper.set_property('token', token)
         self.config_helper.set_property('cnsc', cnsc)

--- a/main.py
+++ b/main.py
@@ -75,6 +75,13 @@ def run_new_token(email='', password=''):
     config = ConfigHelper()
     config.load()  # because we do not want to override the other settings
 
+    logging.basicConfig(
+        filename='DualisWatcher.log', level=logging.DEBUG,
+        format='%(asctime)s  %(levelname)s  {%(module)s}  %(message)s', datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    logging.info('--- run_new_token started ---------------------')
+
     if(not email or not password):
         DualisService(config).interactively_acquire_token()
     else:


### PR DESCRIPTION
Hi there,
thanks for your great work in this dualis script!
I'm running the dualis script using a task schedule. For that i use the ```python main.py --new-token --email wi@dhbw.de --password 1234``` command option to get a new token before each run.
If dualis is online, there is no problem, but when its offline the script is stuck in an endless while loop, because theres no break condition for this `except` code block. This PR is a suggestion how to fix that.

Changes in this PR:
- Added a `retries` condition: after 5 retries the script raises an exception and exits.
- Added logging

Fun fact: while I'm writing this, Dualis is down again...